### PR TITLE
Fix ssl certificate not generated on build-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ build-prod:
 	docker build ./ --tag "openslides-$(SERVICE)" --build-arg CONTEXT="prod" --target "prod"
 
 build-dev:
+	./make-localhost-cert.sh
 	docker build ./ --tag "openslides-$(SERVICE)-dev" --build-arg CONTEXT="dev" --target "dev"
 
 build-test:


### PR DESCRIPTION
fixes additional dev environment setup step mentioned in https://github.com/OpenSlides/OpenSlides/pull/6964